### PR TITLE
Declare libraries properly

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,3 +12,6 @@
 platform = atmelavr
 board = megaatmega2560
 framework = arduino
+lib_deps =
+   seeed-studio/CAN_BUS_Shield @ ^1.20
+   bakercp/PacketSerial @ ^1.4.0


### PR DESCRIPTION
Without that one just gets compiler errors

```
include/e90canbus.h:6:10: fatal error: mcp_can.h: No such file or directory
...
src\main.cpp:8:10: fatal error: PacketSerial.h: No such file or directory
```